### PR TITLE
Mention python3 explicitly for corecount.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ CoreScore is an award-giving benchmark for FPGAs and their synthesis/P&R tools. 
 
 7. Run the corecount utility (Might need to adjust for the correct UART port)
 
-       python fusesoc_libraries/corescore/sw/corecount.py
+       python3 fusesoc_libraries/corescore/sw/corecount.py /dev/ttyUSB0


### PR DESCRIPTION
umsgpack returns different types for python2 and python3.
The easiest fix is to give up on python2 and be explicit that
only python3 is recommended.

Also add port argument to the example for clarity.