### PR TITLE
DE5-Net target

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -41,6 +41,13 @@ filesets:
       - rtl/de0_nano_clock_gen.v : {file_type : verilogSource}
       - rtl/corescore_de0_nano.v : {file_type : verilogSource}
 
+  de5_net:
+    files:
+      - data/de5_net.sdc : {file_type : SDC}
+      - data/de5_net.tcl : {file_type : tclSource}
+      - rtl/de5_net_clock_gen.v : {file_type : verilogSource}
+      - rtl/corescore_de5_net.v : {file_type : verilogSource}
+
   generic:
     files:
       - rtl/corescore_generic.v : {file_type : verilogSource}
@@ -139,6 +146,16 @@ targets:
         family : Cyclone IV E
         device : EP4CE22F17C6
     toplevel: corescore_de0_nano
+
+  de5_net:
+    default_tool : quartus
+    filesets : [rtl, de5_net]
+    generate : [corescorecore_de5_net]
+    tools:
+      quartus:
+        family : Stratix V
+        device : 5SGXEA7N2F45C2
+    toplevel: corescore_de5_net
 
   nexys_a7:
     default_tool: vivado
@@ -242,6 +259,11 @@ generate:
     generator: corescorecore
     parameters:
       count : 61
+
+  corescorecore_de5_net:
+    generator: corescorecore
+    parameters:
+      count : 1568
 
   corescorecore_nexys_a7:
     generator: corescorecore

--- a/data/de5_net.sdc
+++ b/data/de5_net.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {i_clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/data/de5_net.tcl
+++ b/data/de5_net.tcl
@@ -1,0 +1,42 @@
+# OSC_50_B3B - 50 MHz system clock
+set_instance_assignment -name IO_STANDARD "2.5 V" -to i_clk
+set_location_assignment PIN_AW35 -to i_clk
+
+# LED_BRACKET[0]
+set_location_assignment PIN_AH15 -to o_led_n
+set_instance_assignment -name IO_STANDARD "2.5 V" -to o_led_n
+set_instance_assignment -name CURRENT_STRENGTH_NEW 12MA -to o_led_n
+set_instance_assignment -name SLEW_RATE 1 -to o_led_n ; # fast
+
+# CPU_RESET_n
+set_instance_assignment -name IO_STANDARD "2.5 V" -to i_rst_n
+set_location_assignment PIN_BC37 -to i_rst_n
+
+# 7-Segement decimal points
+set_instance_assignment -name IO_STANDARD "1.5 V" -to o_hex0_dp_n
+set_instance_assignment -name IO_STANDARD "1.5 V" -to o_hex1_dp_n
+set_location_assignment PIN_P8  -to o_hex0_dp_n
+set_location_assignment PIN_E9  -to o_hex1_dp_n
+set_instance_assignment -name CURRENT_STRENGTH_NEW 12MA -to o_hex0_dp_n
+set_instance_assignment -name CURRENT_STRENGTH_NEW 12MA -to o_hex1_dp_n
+set_instance_assignment -name SLEW_RATE 1 -to o_hex0_dp_n ; # fast
+set_instance_assignment -name SLEW_RATE 1 -to o_hex1_dp_n ; # fast
+
+# RS422
+set_instance_assignment -name IO_STANDARD "2.5 V" -to o_rs422_de      ; # RS422_DE
+set_instance_assignment -name IO_STANDARD "2.5 V" -to o_uart_txd      ; # RS422_DOUT
+set_instance_assignment -name IO_STANDARD "2.5 V" -to o_rs422_re_n    ; # RS422_RE_n
+set_instance_assignment -name IO_STANDARD "2.5 V" -to o_rs422_te      ; # RS422_TE
+set_location_assignment PIN_AG14 -to o_rs422_de                       ; # RS422_DE
+set_location_assignment PIN_AE17 -to o_uart_txd                       ; # RS422_DOUT
+set_location_assignment PIN_AF17 -to o_rs422_re_n                     ; # RS422_RE_n
+set_location_assignment PIN_AF16 -to o_rs422_te                       ; # RS422_TE
+set_instance_assignment -name CURRENT_STRENGTH_NEW 12MA -to o_rs422_de
+set_instance_assignment -name CURRENT_STRENGTH_NEW 12MA -to o_uart_txd
+set_instance_assignment -name CURRENT_STRENGTH_NEW 12MA -to o_rs422_re_n
+set_instance_assignment -name CURRENT_STRENGTH_NEW 12MA -to o_rs422_te
+set_instance_assignment -name SLEW_RATE 1 -to o_rs422_de     ; # fast
+set_instance_assignment -name SLEW_RATE 1 -to o_uart_txd     ; # fast
+set_instance_assignment -name SLEW_RATE 1 -to o_rs422_re_n   ; # fast
+set_instance_assignment -name SLEW_RATE 1 -to o_rs422_te     ; # fast
+

--- a/rtl/corescore_de5_net.v
+++ b/rtl/corescore_de5_net.v
@@ -1,0 +1,56 @@
+`default_nettype none
+module corescore_de5_net (
+    input wire        i_clk,
+    input wire        i_rst_n,
+    output wire       o_led_n,
+    output wire       o_hex0_dp_n,
+    output wire       o_hex1_dp_n,
+    output wire       o_uart_txd,
+    output wire       o_rs422_de,
+    output wire       o_rs422_re_n,
+    output wire       o_rs422_te
+  );
+
+  wire      clk;
+  wire      rst;
+
+  // Mirror UART output to LED and decimal point on 7-seg
+  assign o_led_n = ~o_uart_txd;
+  assign o_hex0_dp_n = o_uart_txd;
+  assign o_hex1_dp_n = ~o_uart_txd;
+
+  de5_net_clock_gen clock_gen
+    (.i_clk (i_clk),
+     .i_rst (!i_rst_n),
+     .o_clk (clk),
+     .o_rst (rst));
+
+  parameter memfile_emitter = "emitter.hex";
+
+  wire [7:0]  tdata;
+  wire        tlast;
+  wire        tvalid;
+  wire        tready;
+
+  corescorecore corescorecore
+    (.i_clk     (clk),
+     .i_rst     (rst),
+     .o_tdata   (tdata),
+     .o_tlast   (tlast),
+     .o_tvalid  (tvalid),
+     .i_tready  (tready));
+
+  emitter #(.memfile (memfile_emitter)) emitter
+    (.i_clk     (clk),
+     .i_rst     (rst),
+     .i_tdata   (tdata),
+     .i_tlast   (tlast),
+     .i_tvalid  (tvalid),
+     .o_tready  (tready),
+     .o_uart_tx (o_uart_txd));
+
+  assign o_rs422_de = 1'b1;        // Driver enable
+  assign o_rs422_re_n = 1'b1;      // Receiver disabled
+  assign o_rs422_te = 1'b0;        // Disable RS-485 termination
+
+endmodule

--- a/rtl/de5_net_clock_gen.v
+++ b/rtl/de5_net_clock_gen.v
@@ -1,0 +1,37 @@
+`default_nettype none
+module de5_net_clock_gen (
+    input wire  i_clk,
+    input wire  i_rst,
+    output wire o_clk,
+    output wire o_rst
+  );
+
+  wire        locked;
+  reg [9:0]   r;
+
+  assign o_rst = r[9];
+
+  always @(posedge o_clk) begin
+    if (locked)
+      r <= {r[8:0], 1'b0};
+    else
+      r <= 10'b1111111111;
+  end
+
+  wire   clk;
+  assign o_clk = clk;
+
+  altera_pll #(
+    .reference_clock_frequency("50.0 MHz"),
+    .operation_mode("direct"),
+    .output_clock_frequency0("16.000000 MHz")
+  ) altera_pll_i (
+    .rst(i_rst),
+    .outclk({clk}),
+    .locked(locked),
+    .fboutclk(),
+    .fbclk(1'b0),
+    .refclk(i_clk)
+  );
+
+endmodule


### PR DESCRIPTION
Add the DE5-Net Terasic board.

UART is through the RS422 port, mostly due to the lack of GPIO pins. The adapter needed to interface with this UART is sadly quite uncommon but what can you do.

![image](https://user-images.githubusercontent.com/149442/94719449-74b32b00-0353-11eb-8fa5-2e8b3367d3d6.png)

Fitter summary report: https://gist.github.com/bluecmd/7eb4fe82013f1b93108d253152c48b2e