### PR TITLE
Add iCESugar target with core score

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -89,6 +89,11 @@ filesets:
       - rtl/corescore_upduino2.v : {file_type : verilogSource}
       - data/upduino2.pcf : {file_type : PCF}
 
+  icesugar:
+    files:
+      - rtl/corescore_icesugar.v : {file_type : verilogSource}
+      - data/icesugar.pcf : {file_type : PCF}
+
   zcu106:
     files:
       - rtl/corescore_zcu106_clock_gen.v : {file_type : verilogSource}
@@ -223,6 +228,18 @@ targets:
         yosys_synth_options: [-dffe_min_ce_use, 8]
     toplevel : corescore_upduino2
 
+  icesugar:
+    default_tool : icestorm
+    description : iCE40UP5K Development Board by MuseLab
+    filesets : [rtl, icesugar]
+    generate: [corescorecore_icesugar]
+    tools:
+      icestorm:
+        nextpnr_options: [--package, sg48, --up5k, --freq, 16]
+        pnr: next
+        yosys_synth_options: [-dffe_min_ce_use, 8]
+    toplevel : corescore_icesugar
+
   vcu118:
     default_tool: vivado
     filesets : [rtl, vcu118]
@@ -291,6 +308,11 @@ generate:
       count : 55
 
   corescorecore_upduino2:
+    generator: corescorecore
+    parameters:
+      count : 10
+
+  corescorecore_icesugar:
     generator: corescorecore
     parameters:
       count : 10

--- a/data/icesugar.pcf
+++ b/data/icesugar.pcf
@@ -1,0 +1,4 @@
+set_io g 41
+set_io b 39
+set_io r 40
+set_io o_uart_tx 6

--- a/rtl/corescore_icesugar.v
+++ b/rtl/corescore_icesugar.v
@@ -1,0 +1,80 @@
+`default_nettype none
+module corescore_icesugar
+  (
+   output wire g,
+   output wire b,
+   output wire r,
+   output wire o_uart_tx);
+
+   wire        clk48;
+   wire        clk;
+   wire        locked;
+
+
+   SB_HFOSC inthosc
+     (
+      .CLKHFPU(1'b1),
+      .CLKHFEN(1'b1),
+      .CLKHF(clk48));
+
+   SB_PLL40_CORE
+     #(
+       .FEEDBACK_PATH("SIMPLE"),
+       .DIVR(4'b0010),
+       .DIVF(7'b0111111),
+       .DIVQ(3'b110),
+       .FILTER_RANGE(3'b001))
+   pll
+     (.LOCK(locked),
+      .RESETB(1'b1),
+      .BYPASS(1'b0),
+      .REFERENCECLK(clk48),
+      .PLLOUTCORE(clk));
+
+   SB_RGBA_DRV
+     #(
+       .CURRENT_MODE ("0b1"),
+       .RGB0_CURRENT ("0b000111"),
+       .RGB1_CURRENT ("0b000111"),
+       .RGB2_CURRENT ("0b000111"))
+   RGBA_DRIVER
+     (
+      .CURREN(1'b1),
+      .RGBLEDEN(1'b1),
+      .RGB0PWM(o_uart_tx),
+      .RGB1PWM(o_uart_tx),
+      .RGB2PWM(o_uart_tx),
+      .RGB0(g),
+      .RGB1(b),
+      .RGB2(r));
+
+   reg 	     rst = 1'b1;
+
+   always @(posedge clk)
+     rst <= !locked;
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule


### PR DESCRIPTION
iCESugar is quite similar to Upduino2, so supporting it didn't take much effort :)

<img width="1440" alt="Screen Shot 2020-10-02 at 15 35 52" src="https://user-images.githubusercontent.com/13443062/94898956-a90c1180-044f-11eb-9dec-0ca862655887.png">
