### PR TITLE
support for HPCv2 Kintex-7 k420 board w/ 1000 cores@128MHz

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -94,6 +94,13 @@ filesets:
       - data/vivado_waive.tcl : {file_type : tclSource}
       - data/hpc_k7.xdc : {file_type : xdc}
 
+  hpc_ku:
+    files:
+      - rtl/hpc_ku_clock_gen.v : {file_type : verilogSource}
+      - rtl/corescore_hpc_ku.v : {file_type : verilogSource}
+      - data/vivado_waive.tcl : {file_type : tclSource}
+      - data/hpc_ku.xdc : {file_type : xdc}
+
   tb:
     files:
       - tb/corescore_tb.cpp : {file_type : cppSource}
@@ -267,12 +274,21 @@ targets:
 
   hpc_k7:
     default_tool: vivado
-    description: HPCV2 Kintex7 with 750 cores@128MHz + SERV emitter (460800bps UART)
+    description: HPCV2 Kintex7 k7420 with 1024 cores@128MHz + SERV emitter (460800bps UART)
     filesets : [rtl, hpc_k7]
     generate : [corescorecore_hpc_k7]
     tools:
       vivado: {part : xc7k420tffg901-2}
     toplevel : corescore_hpc_k7
+
+  hpc_ku:
+    default_tool: vivado
+    description: HPCV2 KintexUltraScale ku040 with 1024 cores@128MHz + SERV emitter (460800bps UART)
+    filesets : [rtl, hpc_ku]
+    generate : [corescorecore_hpc_ku]
+    tools:
+      vivado: {part : xcku040ffva1156-2}
+    toplevel : corescore_hpc_ku
 
   sim:
     default_tool : verilator
@@ -431,7 +447,12 @@ generate:
   corescorecore_hpc_k7:
     generator: corescorecore
     parameters:
-      count : 1000
+      count : 1024
+
+  corescorecore_hpc_ku:
+    generator: corescorecore
+    parameters:
+      count : 1024
 
   corescorecore_sim:
     generator: corescorecore

--- a/corescore.core
+++ b/corescore.core
@@ -87,6 +87,13 @@ filesets:
       - data/vivado_waive.tcl : {file_type : tclSource}
       - data/nexys_a7.xdc : {file_type : xdc}
 
+  hpc_k7:
+    files:
+      - rtl/hpc_k7_clock_gen.v : {file_type : verilogSource}
+      - rtl/corescore_hpc_k7.v : {file_type : verilogSource}
+      - data/vivado_waive.tcl : {file_type : tclSource}
+      - data/hpc_k7.xdc : {file_type : xdc}
+
   tb:
     files:
       - tb/corescore_tb.cpp : {file_type : cppSource}
@@ -258,6 +265,15 @@ targets:
       vivado: {part : xc7a100tcsg324-1}
     toplevel : corescore_nexys_a7
 
+  hpc_k7:
+    default_tool: vivado
+    description: HPCV2 Kintex7 with 750 cores@128MHz + SERV emitter (460800bps UART)
+    filesets : [rtl, hpc_k7]
+    generate : [corescorecore_hpc_k7]
+    tools:
+      vivado: {part : xc7k420tffg901-2}
+    toplevel : corescore_hpc_k7
+
   sim:
     default_tool : verilator
     description : Verilator testbench with 10 cores + SERV emitter
@@ -411,6 +427,11 @@ generate:
     generator: corescorecore
     parameters:
       count : 268
+
+  corescorecore_hpc_k7:
+    generator: corescorecore
+    parameters:
+      count : 1000
 
   corescorecore_sim:
     generator: corescorecore

--- a/corescore.core
+++ b/corescore.core
@@ -287,7 +287,7 @@ targets:
     filesets : [rtl, hpc_ku]
     generate : [corescorecore_hpc_ku]
     tools:
-      vivado: {part : xcku040ffva1156-2}
+      vivado: {part : xcku040-ffva1156-2-i}
     toplevel : corescore_hpc_ku
 
   sim:

--- a/data/hpc_k7.xdc
+++ b/data/hpc_k7.xdc
@@ -1,0 +1,4 @@
+set_property -dict {PACKAGE_PIN U24  IOSTANDARD LVCMOS33 } [get_ports i_clk];
+set_property -dict {PACKAGE_PIN D16  IOSTANDARD LVCMOS33 } [get_ports o_uart_tx]
+
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports i_clk];

--- a/data/hpc_ku.xdc
+++ b/data/hpc_ku.xdc
@@ -1,0 +1,4 @@
+set_property -dict { PACKAGE_PIN D23 IOSTANDARD LVCMOS18 } [get_ports i_clk];
+set_property -dict { PACKAGE_PIN H27 IOSTANDARD LVCMOS33 } [get_ports o_uart_tx]
+
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports i_clk];

--- a/rtl/corescore_hpc_k7.v
+++ b/rtl/corescore_hpc_k7.v
@@ -1,0 +1,39 @@
+`default_nettype none
+module corescore_hpc_k7
+(
+ input wire  i_clk,
+ output wire o_uart_tx);
+
+   wire      clk;
+   wire      rst;
+
+   hpc_k7_clock_gen clock_gen
+     (.i_clk (i_clk),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule

--- a/rtl/corescore_hpc_ku.v
+++ b/rtl/corescore_hpc_ku.v
@@ -1,0 +1,39 @@
+`default_nettype none
+module corescore_hpc_k7
+(
+ input wire  i_clk,
+ output wire o_uart_tx);
+
+   wire      clk;
+   wire      rst;
+
+   hpc_k7_clock_gen clock_gen
+     (.i_clk (i_clk),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule

--- a/rtl/corescore_hpc_ku.v
+++ b/rtl/corescore_hpc_ku.v
@@ -1,5 +1,5 @@
 `default_nettype none
-module corescore_hpc_k7
+module corescore_hpc_ku
 (
  input wire  i_clk,
  output wire o_uart_tx);
@@ -7,7 +7,7 @@ module corescore_hpc_k7
    wire      clk;
    wire      rst;
 
-   hpc_k7_clock_gen clock_gen
+   hpc_ku_clock_gen clock_gen
      (.i_clk (i_clk),
       .o_clk (clk),
       .o_rst (rst));

--- a/rtl/hpc_k7_clock_gen.v
+++ b/rtl/hpc_k7_clock_gen.v
@@ -1,0 +1,37 @@
+`default_nettype none
+module hpc_k7_clock_gen
+  (input wire  i_clk,
+   output wire o_clk,
+   output reg  o_rst);
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+
+   PLLE2_BASE
+     #(.BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT(16),
+       .CLKIN1_PERIOD(10.0), //100MHz
+       .CLKOUT0_DIVIDE(12.5),
+       .DIVCLK_DIVIDE(1),
+       .STARTUP_WAIT("FALSE"))
+   PLLE2_BASE_inst
+     (.CLKOUT0(o_clk),
+      .CLKOUT1(),
+      .CLKOUT2(),
+      .CLKOUT3(),
+      .CLKOUT4(),
+      .CLKOUT5(),
+      .CLKFBOUT(clkfb),
+      .LOCKED(locked),
+      .CLKIN1(i_clk),
+      .PWRDWN(1'b0),
+      .RST(1'b0),
+      .CLKFBIN(clkfb));
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      o_rst  <= !locked_r;
+   end
+
+endmodule

--- a/rtl/hpc_ku_clock_gen.v
+++ b/rtl/hpc_ku_clock_gen.v
@@ -1,0 +1,37 @@
+`default_nettype none
+module hpc_k7_clock_gen
+  (input wire  i_clk,
+   output wire o_clk,
+   output reg  o_rst);
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+
+   PLLE2_BASE
+     #(.BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT(16),
+       .CLKIN1_PERIOD(10.0), //100MHz
+       .CLKOUT0_DIVIDE(12.5),
+       .DIVCLK_DIVIDE(1),
+       .STARTUP_WAIT("FALSE"))
+   PLLE2_BASE_inst
+     (.CLKOUT0(o_clk),
+      .CLKOUT1(),
+      .CLKOUT2(),
+      .CLKOUT3(),
+      .CLKOUT4(),
+      .CLKOUT5(),
+      .CLKFBOUT(clkfb),
+      .LOCKED(locked),
+      .CLKIN1(i_clk),
+      .PWRDWN(1'b0),
+      .RST(1'b0),
+      .CLKFBIN(clkfb));
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      o_rst  <= !locked_r;
+   end
+
+endmodule

--- a/rtl/hpc_ku_clock_gen.v
+++ b/rtl/hpc_ku_clock_gen.v
@@ -1,5 +1,5 @@
 `default_nettype none
-module hpc_k7_clock_gen
+module hpc_ku_clock_gen
   (input wire  i_clk,
    output wire o_clk,
    output reg  o_rst);


### PR DESCRIPTION
Support for HPCv2 Kintex-7 k420 board w/ 1000 cores@128MHz!

Changes to be committed:
	modified:   corescore.core
	new file:   data/hpc_k7.xdc
	new file:   rtl/corescore_hpc_k7.v
	new file:   rtl/hpc_k7_clock_gen.v
	
Special remarks:

- based in the Nexys board (different FPGA, same tool).
- differently from other corescore boards, I decided increase the core speed by 8x, as long the board calls itself "HPC"
- as effect, the UART speed increased 8x too
- there is room for more cores