### PR TITLE
Add support for Terasic DE10 Nano Kit

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -76,6 +76,13 @@ filesets:
       - rtl/de0_nano_clock_gen.v: { file_type: verilogSource }
       - rtl/corescore_de0_nano.v: { file_type: verilogSource }
 
+  de10_nano:
+    files:
+      - data/de10_nano.sdc: { file_type: SDC }
+      - data/de10_nano.tcl: { file_type: tclSource }
+      - rtl/de0_nano_clock_gen.v: { file_type: verilogSource }
+      - rtl/corescore_de10_nano.v: { file_type: verilogSource }
+
   de5_net:
     files:
       - data/de5_net.sdc: { file_type: SDC }
@@ -277,6 +284,18 @@ targets:
         family: Cyclone IV E
         device: EP4CE22F17C6
     toplevel: corescore_de0_nano
+
+  de10_nano:
+    default_tool: quartus
+    description : Terasic DE10 Nano Kit
+    filesets: [rtl, de10_nano]
+    generate: [corescorecore_de10_nano]
+    tools:
+      quartus:
+        family: Cyclone V
+        device: 5CSEBA6U23I7
+        board_device_index : 2
+    toplevel: corescore_de10_nano
 
   de5_net:
     default_tool: quartus
@@ -484,6 +503,11 @@ generate:
     generator: corescorecore
     parameters:
       count: 61
+
+  corescorecore_de10_nano:
+    generator: corescorecore
+    parameters:
+      count: 271
 
   corescorecore_de5_net:
     generator: corescorecore

--- a/data/de10_nano.sdc
+++ b/data/de10_nano.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {i_clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/data/de10_nano.tcl
+++ b/data/de10_nano.tcl
@@ -1,0 +1,13 @@
+set_location_assignment PIN_V11 -to i_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i_clk
+
+set_location_assignment PIN_W15 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q
+
+# GPIO0 Pin 1
+set_location_assignment PIN_Y15 -to uart_txd
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to uart_txd
+
+#KEY[0]
+set_location_assignment PIN_AH17 -to i_rst_n
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i_rst_n

--- a/rtl/corescore_de10_nano.v
+++ b/rtl/corescore_de10_nano.v
@@ -1,0 +1,45 @@
+`default_nettype none
+module corescore_de10_nano
+(
+ input wire  i_clk,
+ input wire  i_rst_n,
+ output wire q,
+ output wire uart_txd);
+
+   wire      clk;
+   wire      rst;
+
+   //Mirror UART output to LED
+   assign q = uart_txd;
+
+   de0_nano_clock_gen clock_gen
+     (.i_clk (i_clk),
+      .i_rst (!i_rst_n),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (uart_txd));
+
+endmodule


### PR DESCRIPTION
Terasic DE10 Nano kit is a cycloneV SoC (5CSEBA6U23I7) based board
This version has:
- 110K LE
- 5,570 Kbits embedded memory

And the corescore is: 271