### PR TITLE
Add support for EBAZ4205 'Development' Board

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -54,7 +54,7 @@ filesets:
       - data/sockit.tcl: { file_type: tclSource }
       - rtl/de0_nano_clock_gen.v: { file_type: verilogSource }
       - rtl/corescore_sockit.v: { file_type: verilogSource }
-      
+
   storeypeak:
     files:
       - data/storeypeak.tcl: { file_type: tclSource }
@@ -100,6 +100,12 @@ filesets:
       - rtl/corescore_nexys_a7.v: { file_type: verilogSource }
       - data/vivado_waive.tcl: { file_type: tclSource }
       - data/nexys_a7.xdc: { file_type: xdc }
+
+  ebaz4205:
+    files:
+      - rtl/ebaz4205_clock_gen.v: { file_type: verilogSource }
+      - rtl/corescore_ebaz4205.v: { file_type: verilogSource }
+      - data/ebaz4205.xdc: { file_type: xdc }
 
   hpc_k7:
     files:
@@ -258,7 +264,7 @@ targets:
         family: Cyclone V
         device: 5CSXFC6D6F31C6
     toplevel: corescore_sockit
-    
+
   storeypeak:
     default_tool: quartus
     description: Microsoft Storey Peak card
@@ -321,6 +327,15 @@ targets:
     tools:
       vivado: { part: xc7a100tcsg324-1 }
     toplevel: corescore_nexys_a7
+
+  ebaz4205:
+    default_tool: vivado
+    description: EBAZ4205 'Development' Board + SERV emitter
+    filesets: [rtl, ebaz4205]
+    generate: [corescorecore_ebaz4205]
+    tools:
+      vivado: { part: xc7z010clg400-1 }
+    toplevel: corescore_ebaz4205
 
   hpc_k7:
     default_tool: vivado
@@ -536,6 +551,11 @@ generate:
     generator: corescorecore
     parameters:
       count: 268
+
+  corescorecore_ebaz4205:
+    generator: corescorecore
+    parameters:
+      count: 85
 
   corescorecore_hpc_k7:
     generator: corescorecore

--- a/data/ebaz4205.xdc
+++ b/data/ebaz4205.xdc
@@ -1,0 +1,6 @@
+## 33.333 MHz Clock signal
+set_property -dict { PACKAGE_PIN N18 IOSTANDARD LVCMOS33 } [get_ports i_clk];
+create_clock -add -name sys_clk_pin -period 30.00 -waveform {0 5} [get_ports i_clk];
+
+## UART on DATA1_8 pin
+set_property -dict { PACKAGE_PIN B20 IOSTANDARD LVCMOS33 } [get_ports o_uart_tx];

--- a/rtl/corescore_ebaz4205.v
+++ b/rtl/corescore_ebaz4205.v
@@ -1,0 +1,39 @@
+`default_nettype none
+module corescore_ebaz4205
+(
+ input wire  i_clk,
+ output wire o_uart_tx);
+
+   wire      clk;
+   wire      rst;
+
+   ebaz4205_clock_gen clock_gen
+     (.i_clk (i_clk),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule

--- a/rtl/ebaz4205_clock_gen.v
+++ b/rtl/ebaz4205_clock_gen.v
@@ -1,0 +1,37 @@
+`default_nettype none
+module ebaz4205_clock_gen
+  (input wire  i_clk,
+   output wire o_clk,
+   output reg  o_rst);
+
+   wire   clkfb;
+   wire   locked;
+   reg    locked_r;
+
+   PLLE2_BASE
+     #(.BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT(48),
+       .CLKIN1_PERIOD(30.000300003), // 33.333 MHz
+       .CLKOUT0_DIVIDE(100),
+       .DIVCLK_DIVIDE(1),
+       .STARTUP_WAIT("FALSE"))
+   PLLE2_BASE_inst
+     (.CLKOUT0(o_clk),
+      .CLKOUT1(),
+      .CLKOUT2(),
+      .CLKOUT3(),
+      .CLKOUT4(),
+      .CLKOUT5(),
+      .CLKFBOUT(clkfb),
+      .LOCKED(locked),
+      .CLKIN1(i_clk),
+      .PWRDWN(1'b0),
+      .RST(1'b0),
+      .CLKFBIN(clkfb));
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      o_rst  <= !locked_r;
+   end
+
+endmodule

--- a/sw/requirements.txt
+++ b/sw/requirements.txt
@@ -1,0 +1,1 @@
+msgpack


### PR DESCRIPTION
Usage:

```
fusesoc run --target=ebaz4205 corescore

python3 fusesoc_libraries/corescore/sw/corecount.py /dev/ttyUSB0
```

Result: We can fit 85 cores on this board ;)

![Screenshot_2021-08-16_01-57-17](https://user-images.githubusercontent.com/79528/129491839-416949d7-e8a0-4269-a71d-ace1469a4aab.png)

Per-core price:

20.93 USD (my price) / 85 => $0.246235/core

5 USD ("In-China" price) / 85 => $0.0588235/core

References:

- https://github.com/fusesoc/blinky#ebaz4205-development-board
- https://github.com/olofk/serv/#ebaz4205-development-board
- https://github.com/nmigen/nmigen-boards/pull/180 (merged)
- https://github.com/xjtuecho/EBAZ4205#ebaz4205 (mentions "In-China" price)
- The existing 'nexys_a7' example

Note: This PR needs the following patch to build,

```diff
$ git diff
diff --git a/corescore.core b/corescore.core
index 01527de..b68461e 100644
--- a/corescore.core
+++ b/corescore.core
@@ -12,7 +12,7 @@ filesets:
       - rtl/emitter_mux.v
       - rtl/emitter.v
     file_type: verilogSource
-    depend: ["=::serv:1.0.2", servant, serving, verilog-axis]
+    depend: ["serv", servant, serving, verilog-axis]
 
   alhambra_II:
     files:
```

Without this patch, I run into the following Vivado problem,

`ERROR: [Synth 8-7136] In the module 'serv_rf_ram_if' declared at 'workspace/build/corescore_0/src/serv_1.0.2/rtl/serv_rf_ram_if.v:2', parameter 'reset_strategy' used as named parameter override, does not exist [workspace/build/corescore_0/src/serving_1.1.0/serving/serving.v:172]`

But this patch may not be generally applicable for other boards, so it is not a part of this PR.