### PR TITLE
added support for arty-a7-35t

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -12,7 +12,7 @@ filesets:
       - rtl/emitter_mux.v
       - rtl/emitter.v
     file_type: verilogSource
-    depend: ["=::serv:1.0.2", servant, serving, verilog-axis]
+    depend: ["=::serv:1.0.2", servant, "=serving-1.0.2", verilog-axis]
 
   alhambra_II:
     files:
@@ -100,6 +100,13 @@ filesets:
       - rtl/corescore_nexys_a7.v: { file_type: verilogSource }
       - data/vivado_waive.tcl: { file_type: tclSource }
       - data/nexys_a7.xdc: { file_type: xdc }
+  
+  arty_a7_35t:
+    files:
+      - rtl/arty_a7_35t_clock_gen.v: { file_type: verilogSource }
+      - rtl/corescore_arty_a7_35t.v: { file_type: verilogSource }
+      - data/vivado_waive.tcl: { file_type: tclSource }
+      - data/arty_a7_35t.xdc: { file_type: xdc }
 
   hpc_k7:
     files:
@@ -321,6 +328,15 @@ targets:
     tools:
       vivado: { part: xc7a100tcsg324-1 }
     toplevel: corescore_nexys_a7
+  
+  arty_a7_35t:
+    default_tool: vivado
+    description: Digilent Arty A7 35t with 100 cores + SERV emitter
+    filesets: [rtl, arty_a7_35t]
+    generate: [corescorecore_arty_a7_35t]
+    tools:
+      vivado: { part: xc7a35ticsg324-1L }
+    toplevel: corescore_arty_a7_35t
 
   hpc_k7:
     default_tool: vivado
@@ -536,6 +552,11 @@ generate:
     generator: corescorecore
     parameters:
       count: 268
+
+  corescorecore_arty_a7_35t:
+    generator: corescorecore
+    parameters:
+      count: 100
 
   corescorecore_hpc_k7:
     generator: corescorecore

--- a/data/arty_a7_35t.xdc
+++ b/data/arty_a7_35t.xdc
@@ -1,0 +1,9 @@
+# Clock signal
+set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports  i_clk ]; 
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports  i_clk ];
+
+# USB-UART Interface
+set_property -dict { PACKAGE_PIN D10   IOSTANDARD LVCMOS33 } [get_ports o_uart_tx ];
+
+# LEDs
+set_property -dict { PACKAGE_PIN H5    IOSTANDARD LVCMOS33 } [get_ports  q ];

--- a/rtl/arty_a7_35t_clock_gen.v
+++ b/rtl/arty_a7_35t_clock_gen.v
@@ -1,0 +1,37 @@
+`default_nettype none
+module arty_a7_35t_clock_gen
+  (input wire  i_clk,
+   output wire o_clk,
+   output reg  o_rst);
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+
+   PLLE2_BASE
+     #(.BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT(16),
+       .CLKIN1_PERIOD(10.0), //100MHz
+       .CLKOUT0_DIVIDE(100),
+       .DIVCLK_DIVIDE(1),
+       .STARTUP_WAIT("FALSE"))
+   PLLE2_BASE_inst
+     (.CLKOUT0(o_clk),
+      .CLKOUT1(),
+      .CLKOUT2(),
+      .CLKOUT3(),
+      .CLKOUT4(),
+      .CLKOUT5(),
+      .CLKFBOUT(clkfb),
+      .LOCKED(locked),
+      .CLKIN1(i_clk),
+      .PWRDWN(1'b0),
+      .RST(1'b0),
+      .CLKFBIN(clkfb));
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      o_rst  <= !locked_r;
+   end
+
+endmodule

--- a/rtl/corescore_arty_a7_35t.v
+++ b/rtl/corescore_arty_a7_35t.v
@@ -1,0 +1,43 @@
+`default_nettype none
+module corescore_arty_a7_35t
+(
+ input wire  i_clk,
+ output wire q,
+ output wire o_uart_tx);
+
+   wire      clk;
+   wire      rst;
+
+   //Mirror UART output to LED
+   assign q = o_uart_tx;
+
+   arty_a7_35t_clock_gen clock_gen
+     (.i_clk (i_clk),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule


### PR DESCRIPTION
Arty-a7-35t can fit 100 SERV cores into it so can we call it a century by ARTY-a7-35t? 

![corescore_arty](https://user-images.githubusercontent.com/36025181/130335022-2fa41970-0d9f-4916-af27-09de526e3a3c.png)

Here is the design utilization Summary!

![Design_utilization](https://user-images.githubusercontent.com/36025181/130335123-0955e01e-d118-4ee2-b272-7aee0f1f1d67.png)

**One thing more the serving version updated to =serving-1.0.2.**