### PR TITLE
added support for TrenzElectronics MAX1000

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -27,6 +27,13 @@ filesets:
       - rtl/cyc1000_clock_gen.v: { file_type: verilogSource }
       - rtl/corescore_cyc1000.v: { file_type: verilogSource }
 
+  max1000:
+    files:
+      - data/max1000.tcl: { file_type: tclSource }
+      - data/max1000.sdc: { file_type: SDC }
+      - rtl/max1000_clock_gen.v: { file_type: verilogSource }
+      - rtl/corescore_max1000.v: { file_type: verilogSource }
+
   ep2c5t144_devboard:
     files:
       - data/ep2c5t144_devboard.tcl : {file_type : tclSource}
@@ -241,6 +248,17 @@ targets:
         family: Cyclone 10 LP
         device: 10CL025YU256C8G
     toplevel: corescore_cyc1000
+
+  max1000:
+    default_tool: quartus
+    description: TrenzElectronics max1000 with 20 cores + SERV emitter
+    filesets: [rtl, max1000]
+    generate: [corescorecore_max1000]
+    tools:
+      quartus:
+        family: Intel Max10
+        device: 10M08SAU169C8G
+    toplevel: corescore_max1000
 
   ep2c5t144_devboard:
     default_tool: quartus
@@ -550,6 +568,11 @@ generate:
     generator: corescorecore
     parameters:
       count: 60
+
+  corescorecore_max1000:
+    generator: corescorecore
+    parameters:
+      count: 20
 
   corescorecore_ep2c5t144_devboard:
     generator: corescorecore

--- a/data/max1000.sdc
+++ b/data/max1000.sdc
@@ -1,0 +1,8 @@
+# Main system clock (12 Mhz)
+create_clock -name "clk" -period 83.333ns [get_ports {CLK12M}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/data/max1000.tcl
+++ b/data/max1000.tcl
@@ -1,0 +1,7 @@
+set_location_assignment PIN_H6 -to CLK12M
+set_location_assignment PIN_A8 -to q
+set_location_assignment PIN_A4 -to i_uart_rx
+set_location_assignment PIN_B4 -to o_uart_tx
+
+set_global_assignment -name INTERNAL_FLASH_UPDATE_MODE "SINGLE COMP IMAGE WITH ERAM"
+

--- a/rtl/corescore_max1000.v
+++ b/rtl/corescore_max1000.v
@@ -1,0 +1,43 @@
+`default_nettype none
+module corescore_max1000
+(
+ input wire  CLK12M,
+ output wire q,
+ output wire o_uart_tx);
+
+   wire      clk;
+   wire      rst;
+
+   //Mirror UART output to LED
+   assign q = o_uart_tx;
+
+   max1000_clock_gen clock_gen
+     (.i_clk (CLK12M),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule

--- a/rtl/max1000_clock_gen.v
+++ b/rtl/max1000_clock_gen.v
@@ -1,0 +1,113 @@
+`default_nettype none
+module max1000_clock_gen
+  (input wire i_clk,
+   output wire o_clk,
+   output wire o_rst);
+
+   wire        locked;
+   reg [9:0]   r;
+
+   assign o_rst = r[9];
+
+   always @(posedge o_clk)
+     if (locked)
+       r <= {r[8:0],1'b0};
+     else
+       r <= 10'b1111111111;
+
+	altpll	altpll_component (
+				.inclk (i_clk),
+				.clk (o_clk),
+				.locked (locked),
+				.activeclock (),
+				.areset (1'b0),
+				.clkbad (),
+				.clkena ({6{1'b1}}),
+				.clkloss (),
+				.clkswitch (1'b0),
+				.configupdate (1'b0),
+				.enable0 (),
+				.enable1 (),
+				.extclk (),
+				.extclkena ({4{1'b1}}),
+				.fbin (1'b1),
+				.fbmimicbidir (),
+				.fbout (),
+				.fref (),
+				.icdrclk (),
+				.pfdena (1'b1),
+				.phasecounterselect ({4{1'b1}}),
+				.phasedone (),
+				.phasestep (1'b1),
+				.phaseupdown (1'b1),
+				.pllena (1'b1),
+				.scanaclr (1'b0),
+				.scanclk (1'b0),
+				.scanclkena (1'b1),
+				.scandata (1'b0),
+				.scandataout (),
+				.scandone (),
+				.scanread (1'b0),
+				.scanwrite (1'b0),
+				.sclkout0 (),
+				.sclkout1 (),
+				.vcooverrange (),
+				.vcounderrange ());
+	defparam
+		altpll_component.bandwidth_type = "AUTO",
+		altpll_component.clk0_divide_by = 3,
+		altpll_component.clk0_duty_cycle = 50,
+		altpll_component.clk0_multiply_by = 4,
+		altpll_component.clk0_phase_shift = "0",
+		altpll_component.compensate_clock = "CLK0",
+		altpll_component.inclk0_input_frequency = 83333,
+		altpll_component.intended_device_family = "MAX 10",
+		altpll_component.lpm_hint = "CBX_MODULE_PREFIX=pll",
+		altpll_component.lpm_type = "altpll",
+		altpll_component.operation_mode = "NORMAL",
+		altpll_component.pll_type = "AUTO",
+		altpll_component.port_activeclock = "PORT_UNUSED",
+		altpll_component.port_areset = "PORT_UNUSED",
+		altpll_component.port_clkbad0 = "PORT_UNUSED",
+		altpll_component.port_clkbad1 = "PORT_UNUSED",
+		altpll_component.port_clkloss = "PORT_UNUSED",
+		altpll_component.port_clkswitch = "PORT_UNUSED",
+		altpll_component.port_configupdate = "PORT_UNUSED",
+		altpll_component.port_fbin = "PORT_UNUSED",
+		altpll_component.port_inclk0 = "PORT_USED",
+		altpll_component.port_inclk1 = "PORT_UNUSED",
+		altpll_component.port_locked = "PORT_USED",
+		altpll_component.port_pfdena = "PORT_UNUSED",
+		altpll_component.port_phasecounterselect = "PORT_UNUSED",
+		altpll_component.port_phasedone = "PORT_UNUSED",
+		altpll_component.port_phasestep = "PORT_UNUSED",
+		altpll_component.port_phaseupdown = "PORT_UNUSED",
+		altpll_component.port_pllena = "PORT_UNUSED",
+		altpll_component.port_scanaclr = "PORT_UNUSED",
+		altpll_component.port_scanclk = "PORT_UNUSED",
+		altpll_component.port_scanclkena = "PORT_UNUSED",
+		altpll_component.port_scandata = "PORT_UNUSED",
+		altpll_component.port_scandataout = "PORT_UNUSED",
+		altpll_component.port_scandone = "PORT_UNUSED",
+		altpll_component.port_scanread = "PORT_UNUSED",
+		altpll_component.port_scanwrite = "PORT_UNUSED",
+		altpll_component.port_clk0 = "PORT_USED",
+		altpll_component.port_clk1 = "PORT_UNUSED",
+		altpll_component.port_clk2 = "PORT_UNUSED",
+		altpll_component.port_clk3 = "PORT_UNUSED",
+		altpll_component.port_clk4 = "PORT_UNUSED",
+		altpll_component.port_clk5 = "PORT_UNUSED",
+		altpll_component.port_clkena0 = "PORT_UNUSED",
+		altpll_component.port_clkena1 = "PORT_UNUSED",
+		altpll_component.port_clkena2 = "PORT_UNUSED",
+		altpll_component.port_clkena3 = "PORT_UNUSED",
+		altpll_component.port_clkena4 = "PORT_UNUSED",
+		altpll_component.port_clkena5 = "PORT_UNUSED",
+		altpll_component.port_extclk0 = "PORT_UNUSED",
+		altpll_component.port_extclk1 = "PORT_UNUSED",
+		altpll_component.port_extclk2 = "PORT_UNUSED",
+		altpll_component.port_extclk3 = "PORT_UNUSED",
+		altpll_component.self_reset_on_loss_lock = "OFF",
+		altpll_component.width_clock = 5;
+
+endmodule


### PR DESCRIPTION
I tried it on a TrenzElectronics MAX1000 Board which features a Intel Max10 with 8k LEs.

These are my results:
![max1000_corey](https://user-images.githubusercontent.com/44583876/135261853-470ada24-4f13-4283-934c-5a2c4c316ff4.png)

Fitter Status : Successful - Wed Sep 29 13:39:10 2021
Quartus Prime Version : 20.1.1 Build 720 11/11/2020 SJ Lite Edition
Revision Name : corescore_0
Top-level Entity Name : corescore_max1000
Family : MAX 10
Device : 10M08SAU169C8G
Timing Models : Final
Total logic elements : 7,636 / 8,064 ( 95 % )
    Total combinational functions : 6,976 / 8,064 ( 87 % )
    Dedicated logic registers : 5,347 / 8,064 ( 66 % )
Total registers : 5347
Total pins : 3 / 130 ( 2 % )
Total virtual pins : 0
Total memory bits : 44,032 / 387,072 ( 11 % )
Embedded Multiplier 9-bit elements : 0 / 48 ( 0 % )
Total PLLs : 1 / 1 ( 100 % )
UFM blocks : 0 / 1 ( 0 % )
ADC blocks : 0 / 1 ( 0 % )
