### PR TITLE
Add Nexys Video target

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -138,6 +138,13 @@ filesets:
       - data/vivado_waive.tcl: { file_type: tclSource }
       - data/nexys_a7.xdc: { file_type: xdc }
 
+  nexys_video:
+    files:
+      - rtl/nexys_video_clock_gen.v: { file_type: verilogSource }
+      - rtl/corescore_nexys_video.v: { file_type: verilogSource }
+      - data/vivado_waive.tcl: { file_type: tclSource }
+      - data/nexys_video.xdc: { file_type: xdc }
+
   arty_a7:
     files:
       - rtl/arty_a7_clock_gen.v: { file_type: verilogSource }
@@ -440,6 +447,15 @@ targets:
       vivado: { part: xc7a100tcsg324-1 }
     toplevel: corescore_nexys_a7
 
+  nexys_video:
+    default_tool: vivado
+    description: Digilent Nexys Video with 652 cores + SERV emitter
+    filesets: [rtl, nexys_video]
+    generate: [corescorecore_nexys_video]
+    tools:
+      vivado: { part: xc7a200tsbg484-1 }
+    toplevel: corescore_nexys_video
+
   arty_a7_35t:
     default_tool: vivado
     description: Digilent Arty A7 35t with 100 cores + SERV emitter
@@ -723,6 +739,11 @@ generate:
     generator: corescorecore
     parameters:
       count: 268
+
+  corescorecore_nexys_video:
+    generator: corescorecore
+    parameters:
+      count: 652
 
   corescorecore_arty_a7_35t:
     generator: corescorecore

--- a/data/nexys_video.xdc
+++ b/data/nexys_video.xdc
@@ -1,0 +1,4 @@
+set_property -dict {PACKAGE_PIN R4  IOSTANDARD LVCMOS33 } [get_ports i_clk];
+set_property -dict {PACKAGE_PIN AA19  IOSTANDARD LVCMOS33 } [get_ports o_uart_tx];
+
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports i_clk];

--- a/rtl/corescore_nexys_video.v
+++ b/rtl/corescore_nexys_video.v
@@ -1,0 +1,39 @@
+`default_nettype none
+module corescore_nexys_video
+(
+ input wire  i_clk,
+ output wire o_uart_tx);
+
+   wire      clk;
+   wire      rst;
+
+   nexys_video_clock_gen clock_gen
+     (.i_clk (i_clk),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule

--- a/rtl/nexys_video_clock_gen.v
+++ b/rtl/nexys_video_clock_gen.v
@@ -1,0 +1,37 @@
+`default_nettype none
+module nexys_video_clock_gen
+  (input wire  i_clk,
+   output wire o_clk,
+   output reg  o_rst);
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+
+   PLLE2_BASE
+     #(.BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT(16),
+       .CLKIN1_PERIOD(10.0), //100MHz
+       .CLKOUT0_DIVIDE(100),
+       .DIVCLK_DIVIDE(1),
+       .STARTUP_WAIT("FALSE"))
+   PLLE2_BASE_inst
+     (.CLKOUT0(o_clk),
+      .CLKOUT1(),
+      .CLKOUT2(),
+      .CLKOUT3(),
+      .CLKOUT4(),
+      .CLKOUT5(),
+      .CLKFBOUT(clkfb),
+      .LOCKED(locked),
+      .CLKIN1(i_clk),
+      .PWRDWN(1'b0),
+      .RST(1'b0),
+      .CLKFBIN(clkfb));
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      o_rst  <= !locked_r;
+   end
+
+endmodule


### PR DESCRIPTION
This adds support for the Digilent Nexys Video board with 652 SERV cores.

Signed-off-by: Oguz Meteer <info@guztech.nl>