### PR TITLE
Add cmod_a7_35 target.

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -172,6 +172,13 @@ filesets:
       - data/vivado_waive.tcl: { file_type: tclSource }
       - data/arty_a7.xdc: { file_type: xdc }
 
+  cmod_a7:
+    files:
+      - rtl/cmod_a7_clock_gen.v: { file_type: verilogSource }
+      - rtl/corescore_cmod_a7.v: { file_type: verilogSource }
+      - data/vivado_waive.tcl: { file_type: tclSource }
+      - data/cmod_a7.xdc: { file_type: xdc }
+
   ebaz4205:
     files:
       - rtl/ebaz4205_clock_gen.v: { file_type: verilogSource }
@@ -539,6 +546,15 @@ targets:
       vivado: { part: xc7a100tcsg324-1 }
     toplevel: corescore_arty_a7
 
+  cmod_a7_35t:
+    default_tool: vivado
+    description: Digilent CMOD A7 35t with 100 cores + SERV emitter
+    filesets: [rtl, cmod_a7]
+    generate: [corescorecore_cmod_a7_35t]
+    tools:
+      vivado: { part: xc7a35tcpg236-1 }
+    toplevel: corescore_cmod_a7
+
   ebaz4205:
     default_tool: vivado
     description: EBAZ4205 'Development' Board + SERV emitter
@@ -855,6 +871,11 @@ generate:
     generator: corescorecore
     parameters:
       count: 306
+
+  corescorecore_cmod_a7_35t:
+    generator: corescorecore
+    parameters:
+      count: 100
 
   corescorecore_ebaz4205:
     generator: corescorecore

--- a/data/cmod_a7.xdc
+++ b/data/cmod_a7.xdc
@@ -1,0 +1,9 @@
+# Clock signal
+set_property -dict { PACKAGE_PIN L17    IOSTANDARD LVCMOS33 } [get_ports  i_clk ]; 
+create_clock -add -name sys_clk_pin -period 83.33 -waveform {0 41.66} [get_ports  i_clk ];
+
+# USB-UART Interface
+set_property -dict { PACKAGE_PIN J17   IOSTANDARD LVCMOS33 } [get_ports o_uart_tx ];
+
+# LEDs
+set_property -dict { PACKAGE_PIN A17    IOSTANDARD LVCMOS33 } [get_ports  q ];

--- a/rtl/cmod_a7_clock_gen.v
+++ b/rtl/cmod_a7_clock_gen.v
@@ -1,0 +1,34 @@
+`default_nettype none
+module cmod_a7_clock_gen
+  (input wire  i_clk,
+   output wire o_clk,
+   output reg  o_rst);
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+
+   MMCME2_ADV #(
+       .BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT_F(64),
+       .CLKIN1_PERIOD(83.33), // 12 MHz (not possible with PLLE2_BASE)
+       .CLKOUT0_DIVIDE_F(48),
+       .CLKOUT0_PHASE(1'd0),
+       .DIVCLK_DIVIDE(1'd1),
+       .REF_JITTER1(0.01)
+   ) MMCME2_ADV (
+       .CLKFBIN(clkfb),
+       .CLKIN1(i_clk),
+       .PWRDWN(0),
+       .RST(1'b0),
+       .CLKFBOUT(clkfb),
+       .CLKOUT0(o_clk),
+       .LOCKED(locked)
+   );
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      o_rst  <= !locked_r;
+   end
+
+endmodule

--- a/rtl/corescore_cmod_a7.v
+++ b/rtl/corescore_cmod_a7.v
@@ -1,0 +1,43 @@
+`default_nettype none
+module corescore_cmod_a7
+(
+ input wire  i_clk,
+ output wire q,
+ output wire o_uart_tx);
+
+   wire      clk;
+   wire      rst;
+
+   //Mirror UART output to LED
+   assign q = o_uart_tx;
+
+   cmod_a7_clock_gen clock_gen
+     (.i_clk (i_clk),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule


### PR DESCRIPTION
This compiles fine with Vivado 2018.2, however when trying to connect with corecount, it does not print anything.

Resource utilisation is as such:
```
+----------------------------+-------+-------+-----------+-------+
|          Site Type         |  Used | Fixed | Available | Util% |
+----------------------------+-------+-------+-----------+-------+
| Slice LUTs                 | 20287 |     0 |     20800 | 97.53 |
|   LUT as Logic             | 19989 |     0 |     20800 | 96.10 |
|   LUT as Memory            |   298 |     0 |      9600 |  3.10 |
|     LUT as Distributed RAM |    96 |     0 |           |       |
|     LUT as Shift Register  |   202 |     0 |           |       |
| Slice Registers            | 23639 |     0 |     41600 | 56.82 |
|   Register as Flip Flop    | 23639 |     0 |     41600 | 56.82 |
|   Register as Latch        |     0 |     0 |     41600 |  0.00 |
| F7 Muxes                   |   130 |     0 |     16300 |  0.80 |
| F8 Muxes                   |    42 |     0 |      8150 |  0.52 |
+----------------------------+-------+-------+-----------+-------+
```