### PR TITLE
HPCV2 K420T board updated from 1024 to 1276 cores! :)

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -550,7 +550,7 @@ targets:
 
   hpc_k7:
     default_tool: vivado
-    description: HPCV2 Kintex7 k7420 with 1024 cores@128MHz + SERV emitter (460800bps UART)
+    description: HPCV2 Kintex7 k7420 with 1276 cores@16MHz + SERV emitter (57600bps UART)
     filesets : [rtl, hpc_k7]
     generate : [corescorecore_hpc_k7]
     tools:
@@ -864,7 +864,7 @@ generate:
   corescorecore_hpc_k7:
     generator: corescorecore
     parameters:
-      count : 1024
+      count : 1276
 
   corescorecore_marble:
     generator: corescorecore

--- a/rtl/hpc_k7_clock_gen.v
+++ b/rtl/hpc_k7_clock_gen.v
@@ -12,11 +12,11 @@ module hpc_k7_clock_gen
      #(.BANDWIDTH("OPTIMIZED"),
        .CLKFBOUT_MULT(16),
        .CLKIN1_PERIOD(10.0), //100MHz
-       .CLKOUT0_DIVIDE(12.5),
+       .CLKOUT0_DIVIDE(100),
        .DIVCLK_DIVIDE(1),
        .STARTUP_WAIT("FALSE"))
    PLLE2_BASE_inst
-     (.CLKOUT0(o_clk),
+     (.CLKOUT0(o_clk), // 100MHz x 16 / 100 = 16MHz
       .CLKOUT1(),
       .CLKOUT2(),
       .CLKOUT3(),


### PR DESCRIPTION
HPCV2 K420T board updated from 1024 to 1276 cores! :)
Changes to be committed:
	modified:   corescore.core
	modified:   rtl/hpc_k7_clock_gen.v