### PR TITLE
add support for de10_nano with mistral toolchain

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -878,7 +878,7 @@ generate:
   corescorecore_de10_nano_mistral:
     generator: corescorecore
     parameters:
-      count: 74
+      count: 84
 
   corescorecore_de5_net:
     generator: corescorecore

--- a/corescore.core
+++ b/corescore.core
@@ -137,7 +137,6 @@ filesets:
     files:
       - data/de10_nano_mistral.qsf : {file_type: QSF}
       - rtl/corescore_emitter_uart.v: { file_type: verilogSource }
- #     - rtl/de10_nano_mistral_clock_gen.v: { file_type: verilogSource }
       - rtl/corescore_de10_nano_mistral.v: { file_type: verilogSource } 
    
   de5_net:

--- a/corescore.core
+++ b/corescore.core
@@ -132,7 +132,14 @@ filesets:
       - data/de10_nano.tcl: { file_type: tclSource }
       - rtl/de0_nano_clock_gen.v: { file_type: verilogSource }
       - rtl/corescore_de10_nano.v: { file_type: verilogSource }
-
+      
+  de10_nano_mistral:
+    files:
+      - data/de10_nano_mistral.qsf : {file_type: QSF}
+      - rtl/corescore_emitter_uart.v: { file_type: verilogSource }
+ #     - rtl/de10_nano_mistral_clock_gen.v: { file_type: verilogSource }
+      - rtl/corescore_de10_nano_mistral.v: { file_type: verilogSource } 
+   
   de5_net:
     files:
       - data/de5_net.sdc: { file_type: SDC }
@@ -498,6 +505,16 @@ targets:
         board_device_index : 2
     toplevel: corescore_de10_nano
 
+  de10_nano_mistral:
+    default_tool: mistral
+    filesets: [rtl, de10_nano_mistral]
+    generate: [corescorecore_de10_nano_mistral]
+    tools:
+      mistral:
+        yosys_synth_options : [-family cyclonev -nodsp ]
+        device: 5CSEBA6U23I7
+    toplevel: corescore_de10_nano_mistral
+
   de5_net:
     default_tool: quartus
     filesets: [rtl, de5_net]
@@ -851,11 +868,17 @@ generate:
     generator: corescorecore
     parameters:
       count: 61
+      
 
   corescorecore_de10_nano:
     generator: corescorecore
     parameters:
       count: 271
+      
+  corescorecore_de10_nano_mistral:
+    generator: corescorecore
+    parameters:
+      count: 60
 
   corescorecore_de5_net:
     generator: corescorecore

--- a/corescore.core
+++ b/corescore.core
@@ -511,6 +511,7 @@ targets:
     tools:
       mistral:
         yosys_synth_options : [-family cyclonev -nodsp ]
+        nextpnr_options: [--freq,12.5]
         device: 5CSEBA6U23I7
     toplevel: corescore_de10_nano_mistral
 
@@ -877,7 +878,7 @@ generate:
   corescorecore_de10_nano_mistral:
     generator: corescorecore
     parameters:
-      count: 60
+      count: 74
 
   corescorecore_de5_net:
     generator: corescorecore

--- a/data/de10_nano_mistral.qsf
+++ b/data/de10_nano_mistral.qsf
@@ -1,0 +1,14 @@
+set_location_assignment PIN_V11 -to i_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i_clk
+
+#set_location_assignment PIN_W15 -to q
+#set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q
+
+# GPIO0 Pin 1
+set_location_assignment PIN_Y15 -to o_uart_tx
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to uart_txd
+
+#KEY[0]
+set_location_assignment PIN_AH17 -to i_rst_n
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i_rst_n
+

--- a/data/de10_nano_mistral.qsf
+++ b/data/de10_nano_mistral.qsf
@@ -1,8 +1,6 @@
 set_location_assignment PIN_V11 -to i_clk
 set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to i_clk
 
-#set_location_assignment PIN_W15 -to q
-#set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q
 
 # GPIO0 Pin 1
 set_location_assignment PIN_Y15 -to o_uart_tx

--- a/rtl/corescore_de10_nano_mistral.v
+++ b/rtl/corescore_de10_nano_mistral.v
@@ -5,20 +5,22 @@ module corescore_de10_nano_mistral
    input wire i_rst_n,
    output wire o_uart_tx);
 
- //  wire        clk;
- //  wire        locked;
+   
+   reg  div_clk = 0;
+   reg  counter = 0;
+   
 
-  //Create a 16MHz clock from 12MHz using PLL
- // pll pll12
- //   (.clock_in  (i_clk),
- //    .clock_out (clk),
- //    .locked    (locked));
+   always@(posedge i_clk) begin
+
+      counter <= counter + 1;
+      if(counter == 1) div_clk <= ~div_clk;
+      
+   end   
+
+   
    wire	       rst;
    
    assign rst  = !i_rst_n;
-
-  // always @(posedge clk)
-  //   rst <= !locked;
 
    parameter memfile_emitter = "emitter.hex";
 
@@ -28,15 +30,15 @@ module corescore_de10_nano_mistral
    wire        tready;
 
    corescorecore corescorecore
-     (.i_clk     (i_clk),
+     (.i_clk     (div_clk),
       .i_rst     (rst),
       .o_tdata   (tdata),
       .o_tlast   (tlast),
       .o_tvalid  (tvalid),
       .i_tready  (tready));
 
-   corescore_emitter_uart #(.clk_freq_hz (50_000_000)) emitter
-     (.i_clk     (i_clk),
+   corescore_emitter_uart #(.clk_freq_hz (12_500_000)) emitter
+     (.i_clk     (div_clk),
       .i_rst     (rst),
       .i_data    (tdata),
       .i_valid   (tvalid),

--- a/rtl/corescore_de10_nano_mistral.v
+++ b/rtl/corescore_de10_nano_mistral.v
@@ -1,0 +1,47 @@
+
+module corescore_de10_nano_mistral
+  (
+   input  wire     i_clk,
+   input wire i_rst_n,
+   output wire o_uart_tx);
+
+ //  wire        clk;
+ //  wire        locked;
+
+  //Create a 16MHz clock from 12MHz using PLL
+ // pll pll12
+ //   (.clock_in  (i_clk),
+ //    .clock_out (clk),
+ //    .locked    (locked));
+   wire	       rst;
+   
+   assign rst  = !i_rst_n;
+
+  // always @(posedge clk)
+  //   rst <= !locked;
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (i_clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   corescore_emitter_uart #(.clk_freq_hz (50_000_000)) emitter
+     (.i_clk     (i_clk),
+      .i_rst     (rst),
+      .i_data    (tdata),
+      .i_valid   (tvalid),
+      .o_ready   (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule
+


### PR DESCRIPTION
I set 60 cores for now. The highest score I was able to achieve with all cores detected by Corey is 69, but since place and route is different between each build, sometimes a fraction of the 69 cores do not work. Will put in draft mode until I find a score that is reliable.  