### PR TITLE
Fixes a typo in the hx8k target

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -556,7 +556,7 @@ targets:
     description: Lattice iCE40-HX8K development board
     filesets: [base, emitter_serv, hx8k]
     generate:
-      - corescorecore_hx8k: {count: 12}
+      - corescorecore: {count: 12}
       - ice40pll : {freq_in: 12}
     tools:
       icestorm:


### PR DESCRIPTION
I guess this is a typo in the generator for the hx8k target.