### PR TITLE
Add support for AXKU5 dev board

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -41,6 +41,13 @@ filesets:
       - data/vivado_waive.tcl: { file_type: tclSource }
       - data/arty_a7.xdc: { file_type: xdc }
 
+  axku5:
+    files:
+      - rtl/corescore_axku5.v: { file_type: verilogSource }
+      - rtl/corescore_axku5_clock_gen.v: { file_type: verilogSource }
+      - data/vivado_waive.tcl: { file_type: tclSource }
+      - data/axku5.xdc: { file_type: xdc }
+
   chameleon96:
     files:
       - data/chameleon96/chameleon96.sdc : {file_type : SDC}
@@ -399,6 +406,15 @@ targets:
     tools:
       vivado: { part: xc7a100tcsg324-1 }
     toplevel: corescore_arty_a7
+
+  axku5:
+    description: Alinx AXKU5 Evaluation board with 1085 cores + SERV emitter
+    filesets: [base, emitter_serv, axku5]
+    generate: [corescorecore: {count: 1085}]
+    flow: vivado
+    flow_options:
+      part: xcku5p-ffvb676-2-i
+    toplevel: corescore_axku5
 
   chameleon96:
     default_tool : quartus

--- a/data/axku5.xdc
+++ b/data/axku5.xdc
@@ -1,0 +1,9 @@
+set_property PACKAGE_PIN K22 [get_ports i_clk_p]
+set_property PACKAGE_PIN K23 [get_ports i_clk_n]
+set_property IOSTANDARD LVDS [get_ports {i_clk_p i_clk_n}]
+create_clock -name sys_clk_pin -period 5.000 [get_ports i_clk_p]
+
+set_property -dict { PACKAGE_PIN  J12 IOSTANDARD LVCMOS33 } [get_ports { q }];
+set_property -dict { PACKAGE_PIN AD15 IOSTANDARD LVCMOS33 } [get_ports { o_uart_tx }]
+
+set_property RAM_STYLE block [get_cells corescorecore/core_*/serving/ram/mem_reg]

--- a/rtl/corescore_axku5.v
+++ b/rtl/corescore_axku5.v
@@ -1,0 +1,51 @@
+`default_nettype none
+module corescore_axku5
+(
+ input wire  i_clk_p,
+ input wire  i_clk_n,
+ output wire q,
+ output wire o_uart_tx);
+
+   wire      i_clk;
+   wire      clk;
+   wire      rst;
+
+   //Mirror UART output to LED
+   assign q = o_uart_tx;
+
+   IBUFDS ibufds
+     (.I  (i_clk_p),
+      .IB (i_clk_n),
+      .O  (i_clk));
+
+   corescore_axku5_clock_gen
+   clock_gen
+     (.i_clk (i_clk),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule

--- a/rtl/corescore_axku5_clock_gen.v
+++ b/rtl/corescore_axku5_clock_gen.v
@@ -1,0 +1,37 @@
+`default_nettype none
+module corescore_axku5_clock_gen
+  (input wire  i_clk,
+   output wire o_clk,
+   output reg  o_rst);
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+
+   PLLE2_BASE
+     #(.BANDWIDTH("OPTIMIZED"),
+       .CLKFBOUT_MULT(8),
+       .CLKIN1_PERIOD(5.0), //200MHz
+       .CLKOUT0_DIVIDE(100),
+       .DIVCLK_DIVIDE(1),
+       .STARTUP_WAIT("FALSE"))
+   PLLE2_BASE_inst
+     (.CLKOUT0(o_clk), // 16MHz
+      .CLKOUT1(),
+      .CLKOUT2(),
+      .CLKOUT3(),
+      .CLKOUT4(),
+      .CLKOUT5(),
+      .CLKFBOUT(clkfb),
+      .LOCKED(locked),
+      .CLKIN1(i_clk),
+      .PWRDWN(1'b0),
+      .RST(1'b0),
+      .CLKFBIN(clkfb));
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      o_rst  <= !locked_r;
+   end
+
+endmodule


### PR DESCRIPTION
This PR adds support for the AXKU5 dev board.
The corescore for this board is 1085.
The added target uses the new Edalize Flow API.