### PR TITLE
Quantum Machines XCVU13P board (8,300 cores!)

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -305,6 +305,14 @@ filesets:
       - data/libero-post-instructions.txt:
           { file_type: user, copyto: post-instructions.txt }
 
+  qm_xcvu13p:
+    files:
+      - rtl/qm_xcvu13p_clock_gen.v: { file_type: verilogSource }
+      - rtl/corescore_qm_xcvu13p.v: { file_type: verilogSource }
+      - data/vivado_waive.tcl: { file_type: tclSource }
+      - data/qm_xcvu13p.xdc: { file_type: xdc }
+      - data/qm_xcvu13p_settings.tcl: { file_type: tclSource }
+
   sockit:
     files:
       - data/sockit.sdc: { file_type: SDC }
@@ -848,6 +856,14 @@ targets:
       libero:
         <<: *liberoMPF300
         die: MPF300TS_ES
+
+  qm_xcvu13p:
+    default_tool: vivado
+    filesets: [base, emitter_serv, qm_xcvu13p]
+    generate: [corescorecore: {count: 8300}]
+    tools:
+      vivado: { part: xcvu13p-fhga2104-2-e }
+    toplevel: corescore_qm_xcvu13p
 
   sim:
     default_tool: verilator

--- a/data/qm_xcvu13p.xdc
+++ b/data/qm_xcvu13p.xdc
@@ -1,0 +1,18 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN AL20 IOSTANDARD LVCMOS18 } [get_ports i_clk_in];
+create_clock -add -name sysclk -period 10.0 [get_nets i_clk]; # 100 MHz
+
+# EMCCLK is not clock input, so allow it here
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets i_clk]
+
+## LED
+set_property -dict { PACKAGE_PIN BB32 IOSTANDARD LVCMOS12 } [get_ports q];
+
+## UART
+set_property -dict { PACKAGE_PIN AW22 IOSTANDARD LVCMOS18 } [get_ports o_uart_tx]
+set_property -dict { PACKAGE_PIN AW23 IOSTANDARD LVCMOS18 } [get_ports o_uart_tx_dir]
+
+#set_property RAM_STYLE block [get_cells corescorecore/core_*/serving/ram/mem_reg]
+
+# Force all inferred memories within all hierarchical modules to use Block RAM
+set_property RAM_STYLE block [get_cells -hierarchical -filter {IS_PRIMITIVE == 0}]

--- a/data/qm_xcvu13p_settings.tcl
+++ b/data/qm_xcvu13p_settings.tcl
@@ -1,0 +1,34 @@
+# ==========================================
+# Synthesis Settings
+# ==========================================
+
+# Use the highest area optimization strategy
+set_property strategy Flow_AreaOptimized_high [get_runs synth_1]
+
+# Flatten hierarchy to allow cross-boundary optimization
+set_property STEPS.SYNTH_DESIGN.ARGS.FLATTEN_HIERARCHY full [get_runs synth_1]
+
+# Extract all control signals
+set_property STEPS.SYNTH_DESIGN.ARGS.CONTROL_SET_OPT_THRESHOLD 0 [get_runs synth_1]
+
+# Aggressively extract shift registers to SRL primitives
+set_property STEPS.SYNTH_DESIGN.ARGS.SHREG_MIN_SIZE 3 [get_runs synth_1]
+
+# Maximize resource sharing to minimize duplicate arithmetic logic
+set_property STEPS.SYNTH_DESIGN.ARGS.RESOURCE_SHARING auto [get_runs synth_1]
+
+# ==========================================
+# P&R Settings
+# ==========================================
+
+# Direct opt_design to run multiple passes for area reduction
+set_property STEPS.OPT_DESIGN.ARGS.DIRECTIVE ExploreArea [get_runs impl_1]
+
+# Use Default placement to avoid timing-driven spreading of logic
+set_property STEPS.PLACE_DESIGN.ARGS.DIRECTIVE Default [get_runs impl_1]
+
+# Disable physical optimization to prevent register duplication for fanout or timing
+set_property STEPS.PHYS_OPT_DESIGN.IS_ENABLED false [get_runs impl_1]
+
+# Use Explore for routing due to congestion
+set_property STEPS.ROUTE_DESIGN.ARGS.DIRECTIVE Explore [get_runs impl_1]

--- a/rtl/corescore_qm_xcvu13p.v
+++ b/rtl/corescore_qm_xcvu13p.v
@@ -1,0 +1,53 @@
+`default_nettype none
+module corescore_qm_xcvu13p
+(
+ input wire  i_clk_in,
+ output wire q,
+ output wire o_uart_tx,
+ output wire o_uart_tx_dir);
+
+   wire      i_clk;
+   wire      clk;
+   wire      rst;
+
+   //Enable UART TX GPIO output
+   assign o_uart_tx_dir = 1;
+
+   //Mirror UART output to LED
+   assign q = o_uart_tx;
+
+   IBUF ibuf
+     (.I  (i_clk_in),
+      .O  (i_clk));
+
+   qm_xcvu13p_clock_gen
+   clock_gen
+     (.i_clk (i_clk),
+      .o_clk (clk),
+      .o_rst (rst));
+
+   parameter memfile_emitter = "emitter.hex";
+
+   wire [7:0]  tdata;
+   wire        tlast;
+   wire        tvalid;
+   wire        tready;
+
+   corescorecore corescorecore
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .o_tdata   (tdata),
+      .o_tlast   (tlast),
+      .o_tvalid  (tvalid),
+      .i_tready  (tready));
+
+   emitter #(.memfile (memfile_emitter)) emitter
+     (.i_clk     (clk),
+      .i_rst     (rst),
+      .i_tdata   (tdata),
+      .i_tlast   (tlast),
+      .i_tvalid  (tvalid),
+      .o_tready  (tready),
+      .o_uart_tx (o_uart_tx));
+
+endmodule

--- a/rtl/qm_xcvu13p_clock_gen.v
+++ b/rtl/qm_xcvu13p_clock_gen.v
@@ -1,0 +1,38 @@
+`default_nettype none
+module qm_xcvu13p_clock_gen
+  (input wire  i_clk,
+   output wire o_clk,
+   output wire o_rst);
+
+   wire   clkfb;
+   wire   locked;
+   reg 	  locked_r;
+   reg 	  rst = 1'b1;
+
+   assign o_rst = rst;
+
+   MMCME4_BASE
+     #(.DIVCLK_DIVIDE    (1),
+       .CLKFBOUT_MULT_F  (16.0),
+       .CLKOUT0_DIVIDE_F (100.0),
+       .CLKIN1_PERIOD    (10.0), // 100 MHz
+       .STARTUP_WAIT     ("FALSE"))
+   mmcm
+     (.CLKFBOUT    (clkfb),
+      .CLKOUT0     (o_clk),
+      .CLKIN1      (i_clk),
+      .LOCKED      (locked),
+      .PWRDWN      (1'b0),
+      .RST         (1'b0),
+      .CLKFBIN     (clkfb));
+
+   always @(posedge o_clk) begin
+      locked_r <= locked;
+      if (locked_r) begin
+          rst <= 1'b0;
+      end else begin
+          rst <= rst;
+      end
+   end
+
+endmodule


### PR DESCRIPTION
I have run corescore on some additional eBay junk and achieved 8,300 cores :-)

This PR adds support for the pictured Quantum Machines board with a XCVU13P-FHGA2104-2 on it. It finishes bitstream generation without forcing things into BRAMs, but there's a smidge of hold violation (-0.037). It wouldn't be very sporting to submit with timing failing, so the BRAM directive takes care of that 👍 

<img width="1402" height="892" alt="image" src="https://github.com/user-attachments/assets/57fa29b4-90ff-450c-b85d-e286b2882828" />

<img width="1402" height="892" alt="image" src="https://github.com/user-attachments/assets/f86b642b-41c8-465d-ad07-680b133eee8b" />
