### PR TITLE
Add DE25-Nano target

### DIFF
--- a/corescore.core
+++ b/corescore.core
@@ -111,6 +111,12 @@ filesets:
       - rtl/de0_nano_clock_gen.v: { file_type: verilogSource }
       - rtl/corescore_de10_nano.v: { file_type: verilogSource }
 
+  de25_nano:
+    files:
+      - data/de25_nano.tcl: { file_type: tclSource }
+      - data/agilex50MHz.sdc: { file_type: SDC }
+      - rtl/corescore_agilex.v: { file_type: verilogSource }
+
   de5_net:
     files:
       - data/de5_net.sdc: { file_type: SDC }
@@ -544,6 +550,17 @@ targets:
         device: 5CSEBA6U23I7
         board_device_index : 2
     toplevel: corescore_de10_nano
+
+  de25_nano:
+    default_tool: quartus
+    description: Terasic DE25-Nano Agilex 5 with JTAG UART
+    filesets: [base, de25_nano]
+    generate: [corescorecore: {count: 298}]
+    tools:
+      quartus:
+        family: Agilex 5
+        device: A5EB013BB23BE4SR1
+    toplevel: corescore_agilex
 
   de5_net:
     default_tool: quartus

--- a/data/de25_nano.tcl
+++ b/data/de25_nano.tcl
@@ -1,0 +1,25 @@
+set_global_assignment -name MIN_CORE_JUNCTION_TEMP 0
+set_global_assignment -name MAX_CORE_JUNCTION_TEMP 100
+set_global_assignment -name ERROR_CHECK_FREQUENCY_DIVISOR 256
+set_global_assignment -name PWRMGT_VOLTAGE_OUTPUT_FORMAT "LINEAR FORMAT"
+set_global_assignment -name PWRMGT_LINEAR_FORMAT_N "-12"
+set_global_assignment -name POWER_APPLY_THERMAL_MARGIN ADDITIONAL
+
+set_global_assignment -name VERILOG_CU_MODE MFCU
+set_global_assignment -name OPTIMIZATION_MODE "AGGRESSIVE AREA"
+
+set_global_assignment -name ERROR_ON_WARNINGS_PARSING_SDC_ON_RTL_CONSTRAINTS ON
+set_global_assignment -name ERROR_ON_WARNINGS_LOADING_SDC_ON_RTL_CONSTRAINTS ON
+set_global_assignment -name RTL_SDC_FILE src/corescore_0/data/agilex50MHz.sdc
+
+set_location_assignment PIN_V16 -to i_clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_clk
+
+set_location_assignment PIN_C8 -to i_rstn
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to i_rstn
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to i_rstn
+
+set_parameter -name PLL_REF_CLK_FREQ "50.0 MHz"
+set_parameter -name PLL_N_DIV 1
+set_parameter -name PLL_M_DIV 16
+set_parameter -name PLL_OUT_DIV 50


### PR DESCRIPTION
# Add Terasic DE25-Nano Agilex 5 target

Adds support for the Terasic DE25-Nano Agilex 5 board.

Validated with Quartus Prime Pro 26.1 on `A5EB013BB23BE4SR1`:

- 298 cores fits and passes timing
- 299 cores fails by LAB utilization: 4681 LABs required, 4680 available

Final 298-core fit:

- Logic utilization: 46,272 / 46,800 ALMs
- RAM blocks: 298 / 358